### PR TITLE
Dockerize the server with Python 3.7.3 & CUDA 10.1 on Ubuntu 18.04 LTS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,8 @@ This document has the following sections:
 
 - [Setup](#setup)
 - [Testing](#testing)
-- [Running the Server](#running-the-server)
+- [Running The Server](#running-the-server)
+- [Building The Container](#building-the-container)
 
 ## Setup
 
@@ -41,3 +42,32 @@ For a more production-ready server, run the following, which will use [`gunicorn
 ```
 make serve
 ```
+
+# Building The Container
+
+To build a container which can run the application server, use the following Make command:
+
+```
+make container
+```
+
+Under the hood, this will run a `docker build` command with the appropriate container tag, environment variables, etc. If the command is successful, a container name will be printed out at the end. You might see something like:
+
+```
+Step 19/19 : CMD gunicorn -w $WORKERS -b 0.0.0.0:80 ccai.app.bin.webserver:app
+ ---> Using cache
+ ---> 5aac2c0f7c37
+Successfully built 5aac2c0f7c37
+Successfully tagged ccai/floods-backend:f2be8ff7ef4162e74ea848120aa7c20f90251249
+```
+
+You can then take this container name (the part after "Successfully tagged") and run it as such:
+
+```
+docker run \
+  -e WORKERS=$(sysctl -n hw.ncpu) \
+  -p 5000:80 \
+  ccai/floods-backend:f2be8ff7ef4162e74ea848120aa7c20f90251249
+```
+
+As you can see here, you are also able to map port 80 in the container to port 5000 locally as well as specify the number of worker processes to use via the `WORKERS` environment variable.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM nvidia/cuda:10.1-base
+
+# General container initialization
+RUN apt-get update
+
+# Install pyenv to manage the required version of Python
+RUN apt-get install git -y
+RUN git clone https://github.com/pyenv/pyenv.git /root/.pyenv
+RUN cd /root/.pyenv && git checkout v1.2.11
+
+# Set the environment variables that are required to use pyenv
+ENV PYENV_ROOT=/root/.pyenv
+ENV PATH=$PYENV_ROOT/bin:$PATH
+
+# Install the required version of Python from source
+RUN apt-get install \
+    build-essential \
+    curl \
+    libbz2-dev \
+    libffi-dev \
+    libssl-dev \
+    libsqlite3-dev \
+    libreadline-dev \
+    zlib1g-dev \
+    -y
+RUN pyenv install 3.7.3
+RUN git clone https://github.com/pyenv/pyenv-virtualenv.git $(pyenv root)/plugins/pyenv-virtualenv
+
+# Copy the application code
+COPY . /floods-backend
+WORKDIR /floods-backend
+RUN pyenv virtualenv 3.7.3 floods-backend-3.7.3
+ENV PATH=/root/.pyenv/versions/3.7.3/envs/floods-backend-3.7.3/bin/:$PATH
+RUN pip install --upgrade pip
+RUN pip install -r ccai/requirements.txt
+
+# Setup the execution environment
+ENV WORKERS=4
+EXPOSE 80
+CMD gunicorn -w $WORKERS -b 0.0.0.0:80 ccai.app.bin.webserver:app

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-export PYTHONPATH := $(shell pwd):$(PYTHONPATH)
+CONTAINER_NAME = ccai/floods-backend
+CONTAINER_TAG = $(shell git rev-parse --verify HEAD)
+PYTHONPATH := $(shell pwd):$(PYTHONPATH)
 
 test:
 	python -m unittest discover ccai/tests
@@ -11,3 +13,9 @@ format:
 
 serve:
 	gunicorn -w $(shell sysctl -n hw.ncpu) -b 0.0.0.0:5000 ccai.app.bin.webserver:app
+
+container:
+	docker build \
+		-f Dockerfile \
+		-t $(CONTAINER_NAME):${CONTAINER_TAG} \
+		.


### PR DESCRIPTION
This PR adds a `Dockerfile` which is based on the `nvidia:cuda:10.1-base` image. From there, I add `pyenv` to install version `3.7.3` of Python and then finally the application dependencies. The server is launched with [Gunicorn](https://gunicorn.org/) on a configurable number of worker processes.

For more information, consider the following documentation which is included in the Contributor Guide:

# Building The Container

To build a container which can run the application server, use the following Make command:

```
make container
```

Under the hood, this will run a `docker build` command with the appropriate container tag, environment variables, etc. If the command is successful, a container name will be printed out at the end. You might see something like:

```
Step 19/19 : CMD gunicorn -w $WORKERS -b 0.0.0.0:80 ccai.app.bin.webserver:app
 ---> Using cache
 ---> 5aac2c0f7c37
Successfully built 5aac2c0f7c37
Successfully tagged ccai/floods-backend:f2be8ff7ef4162e74ea848120aa7c20f90251249
```

You can then take this container name (the part after "Successfully tagged") and run it as such:

```
docker run \
  -e WORKERS=$(sysctl -n hw.ncpu) \
  -p 5000:80 \
  ccai/floods-backend:f2be8ff7ef4162e74ea848120aa7c20f90251249
```

As you can see here, you are also able to map port 80 in the container to port 5000 locally as well as specify the number of worker processes to use via the `WORKERS` environment variable.