### PR TITLE
Retrieve outdoor images as much as we can

### DIFF
--- a/ccai/streetview.py
+++ b/ccai/streetview.py
@@ -13,13 +13,12 @@ def fetch_street_view_image(
     """Retrieve StreetView images for the address."""
     geocoder = GoogleGeocoder(geocoder_api_key)
     result = geocoder.get(address)[0]
-    latitude = str(result.geometry.location.lat)
-    longitude = str(result.geometry.location.lng)
     params = {
         "size": "512x512",
-        "location": ",".join([latitude, longitude]),
+        "location": result.formatted_address,
         "pitch": "0",
         "key": streetview_api_key,
+        "source": "outdoor"
     }
     api_list = gsv_helpers.api_list(params)
     results = gsv_api.results(api_list)


### PR DESCRIPTION
Hi @marpaia @Vahe987 ! @Vahe987 noticied that current API call to backend may sometimes return indoor images, so I made a short commit to help fix it, with 2 adjustments:

- Look only for outdoor images when calling Google Street View.
  - We won't need indoor images to predict floods.
- Use formatted address instead of coordinates to get Street View images.
  - This should prevent Google from converting a generic address (e.g. a street corner) to too-specific coordinates (e.g. a shop in that street corner).