### PR TITLE
Break up the container into a base container and an app container

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ For a more production-ready server, run the following, which will use [`gunicorn
 make serve
 ```
 
-# Building The Container
+## Building The Container
 
 To build a container which can run the application server, use the following Make command:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,4 @@
-FROM nvidia/cuda:10.1-base
-
-# General container initialization
-RUN apt-get update
-
-# Install pyenv to manage the required version of Python
-RUN apt-get install git -y
-RUN git clone https://github.com/pyenv/pyenv.git /root/.pyenv
-RUN cd /root/.pyenv && git checkout v1.2.11
-
-# Set the environment variables that are required to use pyenv
-ENV PYENV_ROOT=/root/.pyenv
-ENV PATH=$PYENV_ROOT/bin:$PATH
-
-# Install the required version of Python from source
-RUN apt-get install \
-    build-essential \
-    curl \
-    libbz2-dev \
-    libffi-dev \
-    libssl-dev \
-    libsqlite3-dev \
-    libreadline-dev \
-    zlib1g-dev \
-    -y
-RUN pyenv install 3.7.3
-RUN git clone https://github.com/pyenv/pyenv-virtualenv.git $(pyenv root)/plugins/pyenv-virtualenv
-
-# Setup the pyenv
-RUN pyenv virtualenv 3.7.3 floods-backend-3.7.3
-ENV PATH=/root/.pyenv/versions/3.7.3/envs/floods-backend-3.7.3/bin/:$PATH
-RUN pip install --upgrade pip
+FROM gcr.io/climatechangeai/floods-backend-base:5dd5850231496b1494a23c54894c08f948b7d78a
 
 # Copy the application code
 COPY . /floods-backend

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -1,0 +1,32 @@
+FROM nvidia/cuda:10.1-base
+
+# General container initialization
+RUN apt-get update
+
+# Install pyenv to manage the required version of Python
+RUN apt-get install git -y
+RUN git clone https://github.com/pyenv/pyenv.git /root/.pyenv
+RUN cd /root/.pyenv && git checkout v1.2.11
+
+# Set the environment variables that are required to use pyenv
+ENV PYENV_ROOT=/root/.pyenv
+ENV PATH=$PYENV_ROOT/bin:$PATH
+
+# Install the required version of Python from source
+RUN apt-get install \
+    build-essential \
+    curl \
+    libbz2-dev \
+    libffi-dev \
+    libssl-dev \
+    libsqlite3-dev \
+    libreadline-dev \
+    zlib1g-dev \
+    -y
+RUN pyenv install 3.7.3
+RUN git clone https://github.com/pyenv/pyenv-virtualenv.git $(pyenv root)/plugins/pyenv-virtualenv
+
+# Setup the pyenv
+RUN pyenv virtualenv 3.7.3 floods-backend-3.7.3
+ENV PATH=/root/.pyenv/versions/3.7.3/envs/floods-backend-3.7.3/bin/:$PATH
+RUN pip install --upgrade pip


### PR DESCRIPTION
So that we don't have to install system libraries and Python every time we build the container, this PR breaks up the current container into a base container that includes all of the base system configurations that we need to run the app as well as an app container which aims to be as minimal as possible.

I have containers building automatically in Google Cloud and this PR increased the speed of container builds from **5 min 24 seconds** to **41 seconds**.