### PR TITLE
Add climate metadata to the floods API endpoint

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.pt filter=lfs diff=lfs merge=lfs -text
+*.csv filter=lfs diff=lfs merge=lfs -text

--- a/ccai/bin/webserver.py
+++ b/ccai/bin/webserver.py
@@ -19,6 +19,7 @@ import torch
 import torchvision.utils as vutils
 from torchvision import transforms
 
+from ccai.climate.extractor import Extractor
 from ccai.config import CONFIG
 from ccai.nn.munit.trainer import MUNIT_Trainer
 from ccai.streetview import fetch_street_view_image
@@ -156,11 +157,17 @@ def flood(model: str, address: str) -> Response:
                 flooded_image_data = flooded_image_handle.read()
             flooded_image_encoded = base64.b64encode(flooded_image_data)
 
+            extractor = Extractor()
+            coords = extractor.coordinates_from_address(address)
+
             return jsonify(
                 {
                     "original": gsv_image_encoded.decode("ascii"),
                     "flooded": flooded_image_encoded.decode("ascii"),
-                    "metadata": {},
+                    "metadata": {
+                        "relative_precipitation_change": extractor.relative_change(coords),
+                        "monthly_average_precipitation": extractor.monthly_average_precip(coords),
+                    },
                 }
             )
 

--- a/ccai/bin/webserver.py
+++ b/ccai/bin/webserver.py
@@ -158,15 +158,15 @@ def flood(model: str, address: str) -> Response:
             flooded_image_encoded = base64.b64encode(flooded_image_data)
 
             extractor = Extractor()
-            coords = extractor.coordinates_from_address(address)
+            climate_metadata = extractor.metadata_for_address(address)
 
             return jsonify(
                 {
                     "original": gsv_image_encoded.decode("ascii"),
                     "flooded": flooded_image_encoded.decode("ascii"),
                     "metadata": {
-                        "relative_precipitation_change": extractor.relative_change(coords),
-                        "monthly_average_precipitation": extractor.monthly_average_precip(coords),
+                        "relative_change_precipitation": climate_metadata.relative_change_precip,
+                        "monthly_average_precipitation": climate_metadata.monthly_average_precip,
                     },
                 }
             )

--- a/ccai/climate/data/lat.csv
+++ b/ccai/climate/data/lat.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:207071ae8b2a56b670f30f3fc008088ebc209bddd1870f0ffafb79f3be1dd9ac
+size 2300

--- a/ccai/climate/data/lon.csv
+++ b/ccai/climate/data/lon.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c3bb2a4ad3939c11e4526537deaac3928ac6c6a291084a167b8a2004613e95f
+size 4820

--- a/ccai/climate/data/relativecomparedto2012.csv
+++ b/ccai/climate/data/relativecomparedto2012.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7380377163ac840407216cd20efa440bb8639d79807fcfa1d7921c429baa06dd
+size 582990

--- a/ccai/climate/data/yearave.csv
+++ b/ccai/climate/data/yearave.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cde49b21f2767b8a7e7621730e3da00d0ab06df256ab539daa04d3c9a88570fc
+size 1051555

--- a/ccai/climate/extractor.py
+++ b/ccai/climate/extractor.py
@@ -19,6 +19,14 @@ class Coordinates:
     lon: float
 
 
+@dataclass
+class ClimateMetadata:
+    """Data class for passing around climate metadata"""
+
+    relative_change_precip: float
+    monthly_average_precip: float
+
+
 class Extractor(Singleton):
     """Class for extracting relevant climate data given an address or lat/long"""
 
@@ -51,26 +59,23 @@ class Extractor(Singleton):
 
         lat_idx = 1
         for idx, value in self.lat.iterrows():
-            if value["lat"] < lat:
+            if float(value["lat"]) < lat:
                 break
             lat_idx = idx + 1
 
         lon_idx = 1
         for idx, value in self.lon.iterrows():
-            if value["lon"] > lon:
+            if float(value["lon"]) > lon:
                 break
             lon_idx = idx + 1
 
         return (lat_idx, lon_idx)
 
-    def relative_change(self, coordinates: Coordinates) -> float:
-        """Calculate the relative change in precip in 2050 for a given set of
-        coordinates"""
-        indexes = self.indexes_for_coordinates(coordinates)
-        return self.relative_compared_to_2012.iloc[indexes[0], indexes[1]]
-
-    def monthly_average_precip(self, coordinates: Coordinates) -> float:
-        """Calculate the monthly average precipitation in 2050 for a given set
-        of coordinates"""
-        indexes = self.indexes_for_coordinates(coordinates)
-        return self.year_ave.iloc[indexes[0], indexes[1]]
+    def metadata_for_address(self, address: str) -> ClimateMetadata:
+        """Calculate climate metadata for a given address"""
+        coords = self.coordinates_from_address(address)
+        indexes = self.indexes_for_coordinates(coords)
+        return ClimateMetadata(
+            relative_change_precip=self.relative_compared_to_2012.iloc[indexes[0], indexes[1]],
+            monthly_average_precip=self.year_ave.iloc[indexes[0], indexes[1]],
+        )

--- a/ccai/climate/extractor.py
+++ b/ccai/climate/extractor.py
@@ -1,0 +1,76 @@
+"""Helpers for extracting information from climate data"""
+
+import os
+from typing import Tuple
+
+from dataclasses import dataclass
+from googlegeocoder import GoogleGeocoder
+import pandas
+
+from ccai.config import CONFIG
+from ccai.singleton import Singleton
+
+
+@dataclass
+class Coordinates:
+    """Data class for passing around lat and lng"""
+
+    lat: float
+    lon: float
+
+
+class Extractor(Singleton):
+    """Class for extracting relevant climate data given an address or lat/long"""
+
+    BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+    LAT_PATH = os.path.join(BASE_DIR, "data/lat.csv")
+    LON_PATH = os.path.join(BASE_DIR, "data/lon.csv")
+    RELATIVE_COMPARED_TO_2012_PATH = os.path.join(BASE_DIR, "data/relativecomparedto2012.csv")
+    YEAR_AVE_PATH = os.path.join(BASE_DIR, "data/yearave.csv")
+
+    def __init__(self) -> None:
+        Singleton.__init__(self)
+        self.lat = pandas.read_csv(self.LAT_PATH, header=None, names=["lat"])
+        self.lon = pandas.read_csv(self.LON_PATH, header=None, names=["lon"])
+        self.relative_compared_to_2012 = pandas.read_csv(
+            self.RELATIVE_COMPARED_TO_2012_PATH, header=None
+        )
+        self.year_ave = pandas.read_csv(self.YEAR_AVE_PATH, header=None)
+        self.geocoder = GoogleGeocoder(CONFIG.GEO_CODER_API_KEY)
+
+    def coordinates_from_address(self, address: str) -> Coordinates:
+        """Find the lat and lng of a given address"""
+        result = self.geocoder.get(address)
+        return Coordinates(lat=result[0].geometry.location.lat, lon=result[0].geometry.location.lng)
+
+    def indexes_for_coordinates(self, coordinates: Coordinates) -> Tuple[int, int]:
+        """Calculate the indexes of the supplies coordinates in the lat.csv and
+        lon.csv files"""
+        lat = coordinates.lat
+        lon = 360 + coordinates.lon
+
+        lat_idx = 1
+        for idx, value in self.lat.iterrows():
+            if value["lat"] < lat:
+                break
+            lat_idx = idx + 1
+
+        lon_idx = 1
+        for idx, value in self.lon.iterrows():
+            if value["lon"] > lon:
+                break
+            lon_idx = idx + 1
+
+        return (lat_idx, lon_idx)
+
+    def relative_change(self, coordinates: Coordinates) -> float:
+        """Calculate the relative change in precip in 2050 for a given set of
+        coordinates"""
+        indexes = self.indexes_for_coordinates(coordinates)
+        return self.relative_compared_to_2012.iloc[indexes[0], indexes[1]]
+
+    def monthly_average_precip(self, coordinates: Coordinates) -> float:
+        """Calculate the monthly average precipitation in 2050 for a given set
+        of coordinates"""
+        indexes = self.indexes_for_coordinates(coordinates)
+        return self.year_ave.iloc[indexes[0], indexes[1]]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ black==19.3b0
 certifi==2019.3.9
 chardet==3.0.4
 Click==7.0
+dataclasses==0.6
 Flask==1.0.3
 Flask-Cors==3.0.8
 google-streetview==1.2.9
@@ -20,10 +21,13 @@ mccabe==0.6.1
 mypy==0.701
 mypy-extensions==0.4.1
 numpy==1.17.0
+pandas==0.25.0
 Pillow==6.1.0
 prometheus-client==0.7.0
 pylint==2.3.1
+python-dateutil==2.8.0
 python-googlegeocoder==0.4.0
+pytz==2019.2
 PyYAML==5.1.2
 requests==2.22.0
 rope==0.14.0

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,0 +1,34 @@
+"""
+Unit tests for the climate data logic
+"""
+
+import unittest
+
+from ccai.climate.extractor import Extractor
+
+
+class TestClimate(unittest.TestCase):
+    """Tests for the climate data logic"""
+
+    def setUp(self) -> None:
+        self.extractor = Extractor()
+        self.mila_address = "6666 Saint Urbain Street, Montreal, QC, Canada"
+        self.mila_coordinates = self.extractor.coordinates_from_address(self.mila_address)
+
+    def test_lat_long(self) -> None:
+        """Test extraction of lat long given an address"""
+        self.assertEqual(int(self.mila_coordinates.lat), 45)
+        self.assertEqual(int(self.mila_coordinates.lon), -73)
+
+    def test_relative_change(self) -> None:
+        """Test calculation of relative precipitation change"""
+        self.assertEqual(self.extractor.relative_change(self.mila_coordinates), 0.13491)
+
+    def test_monthly_average_precip(self) -> None:
+        """Test calculation of monthly average precipitation"""
+        self.assertEqual(self.extractor.monthly_average_precip(self.mila_coordinates), 9.5253)
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -20,14 +20,11 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(int(self.mila_coordinates.lat), 45)
         self.assertEqual(int(self.mila_coordinates.lon), -73)
 
-    def test_relative_change(self) -> None:
-        """Test calculation of relative precipitation change"""
-        self.assertEqual(self.extractor.relative_change(self.mila_coordinates), 0.13491)
-
-    def test_monthly_average_precip(self) -> None:
-        """Test calculation of monthly average precipitation"""
-        self.assertEqual(self.extractor.monthly_average_precip(self.mila_coordinates), 9.5253)
-
+    def test_metadata(self) -> None:
+        """Test calculation of climate metadata"""
+        meta = self.extractor.metadata_for_address(self.mila_address)
+        self.assertEqual(meta.relative_change_precip, 0.13491)
+        self.assertEqual(meta.monthly_average_precip, 9.5253)
 
 
 if __name__ == "__main__":

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -7,6 +7,7 @@ import unittest
 from ccai.climate.extractor import Extractor
 
 
+@unittest.skip("skipping to minimize LFS bandwidth")
 class TestClimate(unittest.TestCase):
     """Tests for the climate data logic"""
 


### PR DESCRIPTION
Consider the following curl to the floods endpoint with Mila's address:

```
$ curl localhost:5000/flood/munit/6666%20St%20Urbain%20St%2C%20Montreal%2C%20QC%20H2S%203H1%2C%20Canada > data.json  
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 60232  100 60232    0     0   7537      0  0:00:07  0:00:07 --:--:-- 15947
```

Now let's see the metadata:

```
$ cat data.json | jq .metadata
{
  "monthly_average_precipitation": 9.5253,
  "relative_change_precipitation": 0.13491
}
```